### PR TITLE
Create make_home_links.sh

### DIFF
--- a/system-odroidgo2/firstboot2.sh
+++ b/system-odroidgo2/firstboot2.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+ln -s /home/odroid/.emulationstation/themes/ /home/odroid/themes
+ln -s /home/odroid/.config/retroarch/bios /home/odroid/bios
 mkdir -p /var/lib/alsa
 chmod 755 /var/lib/alsa
 amixer set 'Playback Path' 'SPK'

--- a/system-odroidgo2/make_home_links.sh
+++ b/system-odroidgo2/make_home_links.sh
@@ -1,4 +1,0 @@
-##/bin/bash
-
-ln -s /home/odroid/.emulationstation/themes/ /home/odroid/themes
-ln -s /home/odroid/.config/retroarch/bios /home/odroid/bios

--- a/system-odroidgo2/make_home_links.sh
+++ b/system-odroidgo2/make_home_links.sh
@@ -1,0 +1,4 @@
+##/bin/bash
+
+ln -s /home/odroid/.emulationstation/themes/ /home/odroid/themes
+ln -s /home/odroid/.config/retroarch/bios /home/odroid/bios


### PR DESCRIPTION
This script will create links in the root of the home directory so users have easy access to add custom themes and BIOS files, without having to mess around with making hidden folders visible.  It should probably be run on the second boot (first boot after the resize).