### PR TITLE
Update es_systems.cfg

### DIFF
--- a/emulationstation-odroidgo2/es_systems.cfg
+++ b/emulationstation-odroidgo2/es_systems.cfg
@@ -14,7 +14,7 @@
 		<fullname>Sega Dreamcast</fullname>
 		<path>/roms/dreamcast/</path>
 		<extension>.gdi .GDI .cdi .CDI</extension>
-		<command>performance on; /usr/bin/retroarch -L ~/.config/retroarch/cores/flycast_libretro.so %ROM%; performance off</command>
+		<command>performance on; retrorun -s ~ -d ~/.config/retroarch/cores ~/.config/retroarch/cores/flycast_libretro.so %ROM%; performance off</command>
 		<platform>dreamcast</platform>
 		<theme>dreamcast</theme>
 	</system>


### PR DESCRIPTION
Switch Dreamcast to use RetroRun rather than RetroArch (which was failing to launch). RetroArch can still be used manually if desired.