### PR TITLE
Update es_systems.cfg

### DIFF
--- a/emulationstation-odroidgo2/es_systems.cfg
+++ b/emulationstation-odroidgo2/es_systems.cfg
@@ -455,7 +455,7 @@
 		<fullname>Atari Lynx</fullname>
 		<path>/roms/atarilynx/</path>
 		<extension>.lnx .LNX .zip .ZIP</extension>
-		<command>/usr/bin/retroarch -L ~/.config/retroarch/cores/handy_libretro.so %ROM%</command>
+		<command>/usr/bin/retroarch -L ~/.config/retroarch/cores/mednafen_lynx_libretro.so %ROM%</command>
 		<platform>atarilynx</platform>
 		<theme>atarilynx</theme>
 	</system>


### PR DESCRIPTION
Change Atari Lynx emulator from Handy (handy_libretro.so) to Beetle Handy (mednafen_lynx_libretro.so). Handy emulator has severe graphical glitches. Problem can be reproduced in Battlezone 2000. Beetle Handy does not have this problem and runs fine on the OGA.