### PR TITLE
Add libgo2 dep to nmui-odroidgo2

### DIFF
--- a/nmui-odroidgo2/PKGBUILD
+++ b/nmui-odroidgo2/PKGBUILD
@@ -10,6 +10,7 @@ pkgdesc="nmui by OtherCrashOverride"
 arch=('aarch64')
 url=https://github.com/OtherCrashOverride
 license=('Use on odroidgo2 advance')
+depends=('libgo2')
 source=(
   'nmui'
   'nmui.sh'


### PR DESCRIPTION
nmui failed to launch without libgo2 installed.